### PR TITLE
Back-port memory improvements

### DIFF
--- a/diff3.js
+++ b/diff3.js
@@ -24,83 +24,6 @@
 
 var onp = require('./onp');
 
-function longestCommonSubsequence(file1, file2) {
-  var diff = new onp(file1, file2);
-  diff.compose();
-  var ses = diff.getses();
-
-  var root;
-  var prev;
-  var file1RevIdx = file1.length - 1,
-      file2RevIdx = file2.length - 1;
-  for (var i = ses.length - 1; i >= 0; --i) {
-      if (ses[i].t === diff.SES_COMMON) {
-        if (prev) {
-          prev.chain = {
-            file1index: file1RevIdx,
-            file2index: file2RevIdx,
-            chain: null
-          };
-          prev = prev.chain;
-        } else {
-          root = {
-            file1index: file1RevIdx,
-            file2index: file2RevIdx,
-            chain: null
-          };
-          prev = root;
-        }
-        file1RevIdx--;
-        file2RevIdx--;
-      } else if (ses[i].t === diff.SES_DELETE) {
-        file1RevIdx--;
-      } else if (ses[i].t === diff.SES_ADD) {
-        file2RevIdx--;
-      }
-  }
-
-  var tail = {
-    file1index: -1,
-    file2index: -1,
-    chain: null
-  };
-
-  if (!prev) {
-    return tail;
-  }
-
-  prev.chain = tail;
-
-  return root;
-}
-
-function diffIndices(file1, file2) {
-  // We apply the LCS to give a simple representation of the
-  // offsets and lengths of mismatched chunks in the input
-  // files. This is used by diff3_merge_indices below.
-
-  var result = [];
-  var tail1 = file1.length;
-  var tail2 = file2.length;
-
-  for (var candidate = longestCommonSubsequence(file1, file2); candidate !== null; candidate = candidate.chain) {
-    var mismatchLength1 = tail1 - candidate.file1index - 1;
-    var mismatchLength2 = tail2 - candidate.file2index - 1;
-    tail1 = candidate.file1index;
-    tail2 = candidate.file2index;
-
-    if (mismatchLength1 || mismatchLength2) {
-      result.push({
-        file1: [tail1 + 1, mismatchLength1],
-        file2: [tail2 + 1, mismatchLength2]
-      });
-    }
-  }
-
-  result.reverse();
-  return result;
-}
-
 function diff3MergeIndices(a, o, b) {
   // Given three files, A, O, and B, where both A and B are
   // independently derived from O, returns a fairly complicated
@@ -115,8 +38,8 @@ function diff3MergeIndices(a, o, b) {
   // (http://www.cis.upenn.edu/~bcpierce/papers/diff3-short.pdf)
   var i;
 
-  var m1 = diffIndices(o, a);
-  var m2 = diffIndices(o, b);
+  var m1 = new onp(o, a).compose();
+  var m2 = new onp(o, b).compose();
 
   var hunks = [];
 


### PR DESCRIPTION
This PR is a little weird, mostly because `onp.js` is ancient JavaScript that doesn't read too well. To keep this PR within scope, I made my changes while trying to maintain the spirit of what was already there while still affording myself some improvements to help my sanity (for instance, variable names that are a little more descriptive than their one-letter counterparts).

---

Since this is a make or break for our merge conflict editor, I'm going to explain the logic behind my changes. `onp` is a two-way diff algorithm that we like for its theoretical performance. `onp` finds the [shortest edit script](https://en.wikipedia.org/wiki/Longest_common_subsequence_problem) between two input texts. `onp` is implemented a little weird because its basic implementation does not keep track of state, so we have to tack some state of our own onto it in order to return the shortest edit script at the end. The tracking of this state is what was wrong with the old version of `onp.js`, since it would use too much memory and crash. Anyways, back to the shortest edit script.

Essentially, a shortest edit script is a traversal of a line joining the two corners an edit graph:
![Screen Shot 2022-07-01 at 3 12 47 PM](https://user-images.githubusercontent.com/106689772/180837027-97ef71f6-d3d7-4f07-a47e-11529e7b04fe.png)
The old `onp.js` stored diagonal lines efficiently, while storing horizontal/vertical lines inefficiently. A diagonal line represented a path that spans multiple coordinates, so a line from (1, 1) to (5, 5) is represented with only one object. Vertical/horizontal lines needed an object for each coordinate, so around 5 objects for a line spanning (1, 1) to (1, 5). I realized that we only need to store diagonal lines, since the algorithm searches predictably enough to infer the entire shortest edit script from diagonal lines alone (changes to lines 81-87 in the new file). All lines are connected together in a linked list (the `r` property in the object `P` is an integer that indexes into the array `pathposi: P[]`, which represents the object's parent), and I made it so that old diagonal lines in state could be looked up again and connected to new diagonal lines, forgoing the need to store horizontal/vertical lines (previously a series of horizontal/vertical lines would be created to connect two diagonal lines together. I simply cut out the middleman).

Additionally, the output format that we need for the diff3 portion of this library is not the full shortest edit script, so it turns out we don't even have to do any of the aforementioned inference to traverse the shortest edit script to begin with (if you look at the old version of `onp.js`, you will notice that they included an interpolator that iterates through the entire shortest edit script, but this code is not necessary. you can see that i replaced the old interpolator code with something else at lines 120-149 in the new file).

I did regression testing using the old diff3 as the source of truth and I wasn't able to find any failed regression tests. My regression testing was assembled from some shell scripts since I didn't really know how I would go about implementing it for JS, so let me know if you want to see my shell scripts ported over to JS.